### PR TITLE
fix: Remove `user-scalable=no` from viewport in templates

### DIFF
--- a/app/templates/about.ejs
+++ b/app/templates/about.ejs
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <title><%- blogTitle %></title>
 
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
   <link rel="shortcut icon" href="../assets/favicon.ico" type="image/x-icon">

--- a/app/templates/article.ejs
+++ b/app/templates/article.ejs
@@ -7,7 +7,7 @@
     <%- article.title %>
   </title>
 
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
   <link rel="shortcut icon" href="../../assets/favicon.ico" type="image/x-icon">

--- a/app/templates/articles.ejs
+++ b/app/templates/articles.ejs
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <title><%- blogTitle %></title>
 
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
   <link rel="shortcut icon" href="../assets/favicon.ico" type="image/x-icon">

--- a/app/templates/index.ejs
+++ b/app/templates/index.ejs
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <title><%- blogTitle %></title>
 
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
   <link rel="shortcut icon" href="../assets/favicon.ico" type="image/x-icon">

--- a/app/templates/work.ejs
+++ b/app/templates/work.ejs
@@ -7,7 +7,7 @@
     <%- title %>
   </title>
 
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
  
   <link rel="shortcut icon" href="../../assets/favicon.ico" type="image/x-icon">

--- a/app/templates/works.ejs
+++ b/app/templates/works.ejs
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <title><%- blogTitle %></title>
 
-  <meta name="viewport" content="width=device-width, user-scalable=no">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
 
   <link rel="shortcut icon" href="../assets/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
Removed "user-scalable=no" from viewport. Consider avoiding viewport values that prevent users from resizing documents.