### PR TITLE
When building the blog given a CNAME file, then bring the CNAME file over to /dist 

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+test.com

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-test.com

--- a/README.md
+++ b/README.md
@@ -199,6 +199,12 @@ Builds files with parcel bundler.
 
 Builds and deploys the files.
 
+## Adding a custom domain 
+
+Create a CNAME file in the root directory. The build process will automatically pick up on the CNAME for you and you can serve your blog from your custom domain.
+
+To find out more about how Github manages CNAMEs, check out the [docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site)
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -60,5 +60,11 @@ cleancss --batch --batch-suffix '' $DIST/styles/*.css
 echo -e "\n${GREEN}Minify html files...${WHITE}"
 html-minifier --input-dir $DIST --output-dir $DIST --file-ext html --remove-comments --remove-optional-tags --remove-redundant-attributes --remove-script-type-attributes --remove-tag-whitespace --use-short-doctype
 
+
+if test -f "./CNAME"; then
+    echo -e "> Found a CNAME File! Bringing the CNAME over"
+    cp -r ./CNAME ${DIST}/CNAME
+fi
+
 echo -e "\n${CYAN}Done!${WHITE}"
 


### PR DESCRIPTION
Issue: https://github.com/parksb/handmade-blog/issues/52

Changes Introduced: 

Added a small line in the build script which checks if there is a CNAME file in the root folder and brings it over to /dist 
Updated the Readme to add this detail 

### Proof this works: 
Before build, we add a CNAME file in the root (we put test.com inside there) 
<img width="937" alt="image" src="https://user-images.githubusercontent.com/24465934/219973894-9ed83757-151d-4686-81da-c7c2d2f377b0.png">

After build: 
<img width="985" alt="image" src="https://user-images.githubusercontent.com/24465934/219973910-e2f4e725-53f4-4cbf-8a22-a68cdf97ebf6.png">

You can see the CNAME file appear in the built /dist folder 
